### PR TITLE
Create Researchlytic landing page scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,72 @@
-# researchlytic
+# Researchlytic – Research Trends Landing Page
+
+This repository contains a lightweight marketing page for **Researchlytic**, showcasing the research intelligence features that power [researchlytic.com](https://researchlytic.com/research-trends/). It is designed as a static site that you can host anywhere (GitHub Pages, Netlify, Vercel, etc.) or simply open locally in a browser.
+
+## Preview
+
+![Researchlytic preview](assets/placeholder.svg)
+
+> Replace the image above with a hero screenshot of your product for a richer preview.
+
+## Features highlighted on the page
+
+The page mirrors the key sections of the Researchlytic experience:
+
+1. Publication interest over time
+2. Advanced search refinement
+3. Studies, SCR and SCRP metrics
+4. Leading countries analytics
+5. Institutional research insights
+6. Subjects and subtopics discovery
+7. Publisher landscape
+8. Key journals spotlight
+9. Leading researchers overview
+10. Research format breakdown
+11. Open access publishing trends
+12. Highly impactful studies
+13. Recent developments feed
+
+Each section includes a placeholder image that you can replace with the real screenshots you mentioned.
+
+## Project structure
+
+```
+researchlytic/
+├── index.html            # Static landing page markup
+├── styles/
+│   └── main.css          # Styling for the landing page
+├── assets/
+│   └── placeholder.svg   # Temporary artwork until real screenshots are added
+└── README.md             # You are here
+```
+
+## Getting started
+
+1. Clone the repository or download the source.
+2. Open `index.html` directly in your browser to preview the page.
+3. Optionally, serve the project with a simple static server for live reloading:
+   ```bash
+   npx serve
+   ```
+   > Any static file server will work – choose the one you prefer.
+
+## Adding your real screenshots
+
+1. Replace `assets/placeholder.svg` with the screenshots for each section (JPG, PNG, or WebP all work).
+2. Update the `<img>` `src` paths in `index.html` if you decide to rename files per section. The `data-feature` attribute on every image indicates which section it belongs to.
+3. Commit the new assets so your deployment picks them up.
+
+## Customising the content
+
+- **Text** – Update the copy directly in `index.html` to match new messaging.
+- **Styling** – Adjust colours, typography, or layout in `styles/main.css`.
+- **Sections** – Add or remove `<section class="feature-card">...</section>` blocks inside the main grid as your product evolves.
+
+## Deployment tips
+
+- **GitHub Pages** – Enable Pages for the repository and point it to the `main` branch root. The site will be live at `https://<your-username>.github.io/researchlytic/`.
+- **Netlify/Vercel** – Drag-and-drop the folder in their dashboards or connect the Git repo. Since this is a static build, no additional configuration is necessary.
+
+## License
+
+All product copy and screenshots remain proprietary to Researchlytic. The static scaffolding in this repository is provided so you can manage and deploy your own marketing site.

--- a/assets/placeholder.svg
+++ b/assets/placeholder.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 400" role="img" aria-labelledby="title desc">
+  <title>Screenshot placeholder</title>
+  <desc>A light gray placeholder image for Researchlytic screenshots.</desc>
+  <rect width="600" height="400" fill="#f2f4f8"/>
+  <path d="M40 320 L200 180 L320 280 L420 200 L560 320" fill="none" stroke="#a7b4c9" stroke-width="12" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="160" cy="160" r="40" fill="none" stroke="#a7b4c9" stroke-width="12"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="32" font-family="'Segoe UI', Tahoma, sans-serif" fill="#6b7a99">Researchlytic</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,178 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Researchlytic – Research Trends Intelligence</title>
+  <meta name="description" content="Researchlytic helps you uncover global research trends, publication activity, and key contributors for any topic." />
+  <link rel="stylesheet" href="styles/main.css" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+</head>
+<body>
+  <header class="hero">
+    <div class="hero__content">
+      <div class="hero__kicker">Researchlytic</div>
+      <h1 class="hero__title">Discover what the world is researching about</h1>
+      <p class="hero__subtitle">Search any topic and instantly explore research activity, publication momentum, and the people and organisations that shape the conversation.</p>
+      <form class="hero__input" aria-label="Research search form">
+        <label class="sr-only" for="topic-input">Enter a research term or a topic</label>
+        <input id="topic-input" name="topic" type="search" placeholder="Enter a research term or a topic" />
+        <button type="button">Analyze</button>
+      </form>
+    </div>
+  </header>
+
+  <main class="main">
+    <div class="grid">
+      <section class="feature-card" id="publication-interest">
+        <div class="feature-card__content">
+          <div class="feature-card__kicker">Trend intelligence</div>
+          <h2 class="feature-card__title">Publication interest over time</h2>
+          <p class="feature-card__description">See how the popularity of your research keyword has changed over time, and get an idea of the overall trend in research and publication activity related to your keyword.</p>
+        </div>
+        <figure class="feature-card__media">
+          <img src="assets/placeholder.svg" data-feature="publication-interest" alt="Screenshot of publication interest over time chart" />
+        </figure>
+      </section>
+
+      <section class="feature-card" id="refine-your-search">
+        <div class="feature-card__content">
+          <div class="feature-card__kicker">Advanced filters</div>
+          <h2 class="feature-card__title">Refine your search</h2>
+          <p class="feature-card__description">Use advanced filters such as location, period, subjects, and study type to narrow down and refine your search for studies related to your research keyword.</p>
+        </div>
+        <figure class="feature-card__media">
+          <img src="assets/placeholder.svg" data-feature="refine-your-search" alt="Screenshot of filters panel used to refine research" />
+        </figure>
+      </section>
+
+      <section class="feature-card" id="studies-scr">
+        <div class="feature-card__content">
+          <div class="feature-card__kicker">Impact metrics</div>
+          <h2 class="feature-card__title">Studies, SCR and SCRP</h2>
+          <p class="feature-card__description">Analyze metrics such as Studies, SCR (Study to Citation Ratio) and SCRP (Study to Citation Ratio Percentage) to understand the research activity, popularity and impact of a specific research area over time.</p>
+        </div>
+        <figure class="feature-card__media">
+          <img src="assets/placeholder.svg" data-feature="studies-scr" alt="Screenshot highlighting Studies, SCR and SCRP metrics" />
+        </figure>
+      </section>
+
+      <section class="feature-card" id="leading-countries">
+        <div class="feature-card__content">
+          <div class="feature-card__kicker">Global reach</div>
+          <h2 class="feature-card__title">Leading countries in your research area</h2>
+          <p class="feature-card__description">Find out which countries are particularly interested in your research keyword, and identify regional trends in research activity.</p>
+        </div>
+        <figure class="feature-card__media">
+          <img src="assets/placeholder.svg" data-feature="leading-countries" alt="Screenshot showing leading countries in the research area" />
+        </figure>
+      </section>
+
+      <section class="feature-card" id="institutions">
+        <div class="feature-card__content">
+          <div class="feature-card__kicker">Institutional insights</div>
+          <h2 class="feature-card__title">Research interest by institutions</h2>
+          <p class="feature-card__description">See which institutions are actively researching in your field, and get insights into the research focus of different institutions.</p>
+        </div>
+        <figure class="feature-card__media">
+          <img src="assets/placeholder.svg" data-feature="institutions" alt="Screenshot of institutions researching in the selected field" />
+        </figure>
+      </section>
+
+      <section class="feature-card" id="subjects-subtopics">
+        <div class="feature-card__content">
+          <div class="feature-card__kicker">Topic discovery</div>
+          <h2 class="feature-card__title">Research subjects and subtopics</h2>
+          <p class="feature-card__description">Explore the different subjects and subtopics related to your research keyword, and identify the most heavily researched areas within your field.</p>
+        </div>
+        <figure class="feature-card__media">
+          <img src="assets/placeholder.svg" data-feature="subjects-subtopics" alt="Screenshot showing research subjects and subtopics" />
+        </figure>
+      </section>
+
+      <section class="feature-card" id="publishers">
+        <div class="feature-card__content">
+          <div class="feature-card__kicker">Publishing landscape</div>
+          <h2 class="feature-card__title">Publishers in your research domain</h2>
+          <p class="feature-card__description">Identify which publishers are releasing the most research in your domain, and get an idea of how studies are distributed across publishers.</p>
+        </div>
+        <figure class="feature-card__media">
+          <img src="assets/placeholder.svg" data-feature="publishers" alt="Screenshot of publishers leading in the research domain" />
+        </figure>
+      </section>
+
+      <section class="feature-card" id="key-journals">
+        <div class="feature-card__content">
+          <div class="feature-card__kicker">Journal intelligence</div>
+          <h2 class="feature-card__title">Key journals in your research interests</h2>
+          <p class="feature-card__description">Uncover the top journals in your area of interest and understand how studies are distributed across different journals.</p>
+        </div>
+        <figure class="feature-card__media">
+          <img src="assets/placeholder.svg" data-feature="key-journals" alt="Screenshot showcasing key journals for the research topic" />
+        </figure>
+      </section>
+
+      <section class="feature-card" id="leading-researchers">
+        <div class="feature-card__content">
+          <div class="feature-card__kicker">Expert spotlight</div>
+          <h2 class="feature-card__title">Leading researchers in your research topic</h2>
+          <p class="feature-card__description">Identify which researchers are most active in your topic, and explore how research activity is distributed among the experts shaping the field.</p>
+        </div>
+        <figure class="feature-card__media">
+          <img src="assets/placeholder.svg" data-feature="leading-researchers" alt="Screenshot listing leading researchers for the topic" />
+        </figure>
+      </section>
+
+      <section class="feature-card" id="research-types">
+        <div class="feature-card__content">
+          <div class="feature-card__kicker">Format breakdown</div>
+          <h2 class="feature-card__title">Research types in your field</h2>
+          <p class="feature-card__description">Discover the formats that are most common in your field, from research papers to book chapters, conference proceedings and more.</p>
+        </div>
+        <figure class="feature-card__media">
+          <img src="assets/placeholder.svg" data-feature="research-types" alt="Screenshot of research types distribution" />
+        </figure>
+      </section>
+
+      <section class="feature-card" id="open-access">
+        <div class="feature-card__content">
+          <div class="feature-card__kicker">Access model trends</div>
+          <h2 class="feature-card__title">Open access publishing trends</h2>
+          <p class="feature-card__description">Track the adoption of open access publishing in your area and see how it compares with closed access trends over time.</p>
+        </div>
+        <figure class="feature-card__media">
+          <img src="assets/placeholder.svg" data-feature="open-access" alt="Screenshot comparing open access and closed access publishing" />
+        </figure>
+      </section>
+
+      <section class="feature-card" id="impactful-studies">
+        <div class="feature-card__content">
+          <div class="feature-card__kicker">High-impact work</div>
+          <h2 class="feature-card__title">Highly impactful studies</h2>
+          <p class="feature-card__description">Identify the most influential studies for your keyword, guided by citations and other impact indicators that highlight pivotal research.</p>
+        </div>
+        <figure class="feature-card__media">
+          <img src="assets/placeholder.svg" data-feature="impactful-studies" alt="Screenshot featuring highly impactful studies" />
+        </figure>
+      </section>
+
+      <section class="feature-card" id="recent-developments">
+        <div class="feature-card__content">
+          <div class="feature-card__kicker">Stay up to date</div>
+          <h2 class="feature-card__title">Recent developments in research</h2>
+          <p class="feature-card__description">Keep track of the most recent studies published on your keyword, and stay ahead of emerging developments and trends.</p>
+        </div>
+        <figure class="feature-card__media">
+          <img src="assets/placeholder.svg" data-feature="recent-developments" alt="Screenshot highlighting recent research developments" />
+        </figure>
+      </section>
+    </div>
+  </main>
+
+  <footer class="footer">
+    <p><strong>Researchlytic</strong> &mdash; Research intelligence to surface what matters next.</p>
+  </footer>
+</body>
+</html>

--- a/styles/main.css
+++ b/styles/main.css
@@ -1,0 +1,249 @@
+:root {
+  color-scheme: light;
+  --font-base: 'Inter', 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  --color-background: #f5f7fb;
+  --color-surface: #ffffff;
+  --color-text: #1f2937;
+  --color-muted: #4b5563;
+  --color-accent: #2f6fed;
+  --color-accent-soft: rgba(47, 111, 237, 0.08);
+  --max-width: 1100px;
+  --radius: 18px;
+  --shadow: 0 24px 60px rgba(15, 23, 42, 0.12);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-base);
+  background: var(--color-background);
+  color: var(--color-text);
+  line-height: 1.6;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+a {
+  color: inherit;
+}
+
+.hero {
+  background: linear-gradient(135deg, rgba(47, 111, 237, 0.92), rgba(99, 102, 241, 0.9));
+  color: #ffffff;
+  padding: 6rem 1.5rem 5rem;
+  text-align: center;
+  position: relative;
+  overflow: hidden;
+}
+
+.hero::before,
+.hero::after {
+  content: '';
+  position: absolute;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.12);
+  filter: blur(0px);
+  z-index: 0;
+}
+
+.hero::before {
+  width: 400px;
+  height: 400px;
+  top: -180px;
+  right: -140px;
+}
+
+.hero::after {
+  width: 320px;
+  height: 320px;
+  bottom: -160px;
+  left: -100px;
+}
+
+.hero__content {
+  position: relative;
+  z-index: 1;
+  max-width: 760px;
+  margin: 0 auto;
+}
+
+.hero__kicker {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  background-color: rgba(15, 23, 42, 0.35);
+  font-size: 0.9rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 600;
+  margin-bottom: 1.5rem;
+}
+
+.hero__title {
+  font-size: clamp(2.6rem, 5vw, 3.8rem);
+  font-weight: 700;
+  margin: 0 0 1rem;
+}
+
+.hero__subtitle {
+  font-size: 1.2rem;
+  margin: 0 auto 2.5rem;
+  max-width: 48ch;
+  color: rgba(255, 255, 255, 0.88);
+}
+
+.hero__input {
+  display: flex;
+  max-width: 480px;
+  margin: 0 auto;
+  background: #ffffff;
+  border-radius: 999px;
+  padding: 0.35rem 0.35rem 0.35rem 1rem;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.45);
+}
+
+.hero__input input {
+  flex: 1;
+  border: none;
+  outline: none;
+  font-size: 1rem;
+  padding: 0.75rem 0.5rem;
+  border-radius: 999px;
+  color: #1f2937;
+}
+
+.hero__input button {
+  border: none;
+  background: var(--color-accent);
+  color: #fff;
+  font-weight: 600;
+  font-size: 0.95rem;
+  padding: 0.75rem 1.4rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.hero__input button:hover,
+.hero__input button:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 32px rgba(47, 111, 237, 0.24);
+}
+
+.main {
+  max-width: var(--max-width);
+  margin: -3rem auto 4rem;
+  padding: 0 1.5rem 4rem;
+  position: relative;
+  z-index: 2;
+}
+
+.grid {
+  display: grid;
+  gap: 2.5rem;
+}
+
+.feature-card {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.8rem;
+  padding: 2.5rem;
+  border-radius: var(--radius);
+  background: var(--color-surface);
+  box-shadow: var(--shadow);
+  align-items: center;
+}
+
+.feature-card:nth-child(even) .feature-card__content {
+  order: 2;
+}
+
+.feature-card__kicker {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-accent);
+  font-size: 0.8rem;
+  margin-bottom: 0.9rem;
+}
+
+.feature-card__title {
+  font-size: 1.6rem;
+  margin: 0 0 1rem;
+}
+
+.feature-card__description {
+  color: var(--color-muted);
+  margin: 0;
+}
+
+.feature-card__media {
+  position: relative;
+  border-radius: calc(var(--radius) - 6px);
+  overflow: hidden;
+  background: var(--color-accent-soft);
+  min-height: 240px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+}
+
+.feature-card__media img {
+  width: 100%;
+  max-width: 420px;
+  height: auto;
+  display: block;
+  filter: saturate(0.85);
+}
+
+.footer {
+  text-align: center;
+  padding: 3rem 1.5rem 4rem;
+  color: var(--color-muted);
+  font-size: 0.9rem;
+}
+
+.footer strong {
+  color: var(--color-text);
+}
+
+@media (max-width: 720px) {
+  .hero {
+    padding: 5rem 1.25rem 4rem;
+  }
+
+  .feature-card {
+    padding: 1.9rem;
+  }
+
+  .feature-card:nth-child(even) .feature-card__content {
+    order: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add a static Researchlytic landing page that mirrors the research trends sections and provides placeholders for screenshots
- implement styling for hero, feature grid, and accessibility helpers in `styles/main.css`
- document repository structure and instructions for replacing screenshots or deploying the page

## Testing
- not run (static content)

------
https://chatgpt.com/codex/tasks/task_e_68c9d4eed3548333a7cfd8fbd7cc0870